### PR TITLE
fix(个人信息设置): 修复了设置成功不会立即刷新页面的问题

### DIFF
--- a/Stardust/app/src/main/java/org/swsd/stardust/presenter/SetAvatarPresenter.java
+++ b/Stardust/app/src/main/java/org/swsd/stardust/presenter/SetAvatarPresenter.java
@@ -1,6 +1,7 @@
 package org.swsd.stardust.presenter;
 
 import android.content.Context;
+import android.content.Intent;
 import android.os.Handler;
 import android.os.Message;
 import android.widget.Toast;
@@ -23,7 +24,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 
 /**
- * author  ： 胡俊钦
+ * author  ： 胡俊钦，林炜鸿
  * time    ： 2017/11/17
  * desc    ： 修改头像presenter
  * version ： 1.0
@@ -45,6 +46,8 @@ public class SetAvatarPresenter {
                     Toast.makeText(mContext, "更换头像成功！", Toast.LENGTH_SHORT).show();
                     userBean.setAvatarPath(upload.url);
                     userBean.updateAll();
+                    // 发送广播提醒设置页面修改成功
+                    mContext.sendBroadcast(new Intent("reload the setting page"));
                     break;
                 case 403:
                     Toast.makeText(mContext, "头像路径太长，请换一张图片！", Toast.LENGTH_SHORT).show();

--- a/Stardust/app/src/main/java/org/swsd/stardust/presenter/SetNamePresenter.java
+++ b/Stardust/app/src/main/java/org/swsd/stardust/presenter/SetNamePresenter.java
@@ -1,6 +1,7 @@
 package org.swsd.stardust.presenter;
 
 import android.content.Context;
+import android.content.Intent;
 import android.os.Handler;
 import android.os.Message;
 import android.text.Editable;
@@ -25,7 +26,7 @@ import okhttp3.Response;
 
 
 /**
- * author  ： 胡俊钦
+ * author  ： 胡俊钦，林炜鸿
  * time    ： 2017/11/17
  * desc    ： 修改用户名Presenter
  * version ： 1.0
@@ -47,6 +48,8 @@ public class SetNamePresenter {
                 case 200:
                     userBean.setUserName(userName.toString());
                     userBean.updateAll("userId=?", "" + userBean.getUserId());
+                    // 发送广播提醒设置页面修改成功
+                    mContext.sendBroadcast(new Intent("reload the setting page"));
                     Toast.makeText(mContext, "修改用户名成功", Toast.LENGTH_SHORT).show();
                     break;
                 case 409:

--- a/Stardust/app/src/main/java/org/swsd/stardust/view/activity/InfoSettingActivity.java
+++ b/Stardust/app/src/main/java/org/swsd/stardust/view/activity/InfoSettingActivity.java
@@ -2,8 +2,11 @@ package org.swsd.stardust.view.activity;
 
 import android.Manifest;
 import android.annotation.TargetApi;
+import android.content.BroadcastReceiver;
 import android.content.ContentUris;
+import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.database.Cursor;
@@ -30,7 +33,7 @@ import org.swsd.stardust.presenter.UserPresenter;
 import de.hdodenhof.circleimageview.CircleImageView;
 
 /**
- * author     :  胡俊钦
+ * author     :  胡俊钦，林炜鸿
  * time       :  2017/11/07
  * description:  个人信息设置模块
  * version:   :  1.0
@@ -40,6 +43,28 @@ public class InfoSettingActivity extends BaseActivity {
     private static final int CHOOSE_PHOTO = 2;
     UserBean userBean;
     UserPresenter userPresenter = new UserPresenter();
+
+    private BroadcastReceiver bcReload = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            // 从数据库获取用户信息
+            userBean = userPresenter.toGetUserInfo();
+            // 显示用户名
+            TextView tvMyUser = (TextView) findViewById(R.id.tv_setting_username);
+            tvMyUser.setText(userBean.getUserName());
+
+            //根据图片路径显示头像
+            CircleImageView circleImageView = (CircleImageView) findViewById(R.id.civ_setting_photo);
+            if (userBean.getAvatarPath().equals("")) {
+                // 如果头像路径为空，则使用默认头像
+                Glide.with(InfoSettingActivity.this).load(R.drawable.ic_setting_photo)
+                        .into(circleImageView);
+            } else {
+                Glide.with(InfoSettingActivity.this).load(userBean.getAvatarPath())
+                        .into(circleImageView);
+            }
+        }
+    };
 
     @Override
     public int bindLayout() {
@@ -56,6 +81,12 @@ public class InfoSettingActivity extends BaseActivity {
     @Override
     public void initData() {
 
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        unregisterReceiver(bcReload);
     }
 
     @Override
@@ -86,7 +117,8 @@ public class InfoSettingActivity extends BaseActivity {
         initView();
         // 绑定并加载登录界面布局
         bindLayout();
-
+        // 注册刷新页面的广播接收器
+        registerReceiver(bcReload, new IntentFilter("reload the setting page"));
         // 获取顶部状态栏的高度
         Resources resources = getResources();
         int resourceId = resources.getIdentifier("status_bar_height", "dimen", "android");


### PR DESCRIPTION
- 在 SetAvatarPresenter 中发送修改成功的广播
- 在 SetNamePresenter 中发送修改成功的广播
- 在 InfoSettingActivity 中接收广播并再次刷新页面
fix(个人信息设置): 修复了未注销广播接收器的问题

- 在 InfoSettingActivity 的 onDestory() 方法中注销了广播接收器
- 改变广播接收器变量的命名风格